### PR TITLE
Map tab to spaces codemirror

### DIFF
--- a/inginious/frontend/common/static/js/common.js
+++ b/inginious/frontend/common/static/js/common.js
@@ -87,6 +87,12 @@ function registerCodeEditor(textarea, lang, lines)
 
     var is_single = $(textarea).hasClass('single');
 
+    var tabToSpaces = function(codeMirrorInstance) {
+        var indentUnit = codeMirrorInstance.getOption("indentUnit");
+        var spaces = Array(indentUnit + 1).join(" ");
+        codeMirrorInstance.replaceSelection(spaces);
+    }
+
     var editor = CodeMirror.fromTextArea(textarea, {
         lineNumbers:       true,
         mode:              mode["mime"],
@@ -102,7 +108,7 @@ function registerCodeEditor(textarea, lang, lines)
         viewportMargin:    20,
         theme:             "inginious",
         lint:              true,
-        extraKeys:         { "Ctrl-Space": "autocomplete" }
+        extraKeys:         { "Ctrl-Space": "autocomplete", Tab: tabToSpaces }
     });
 
     if(is_single)


### PR DESCRIPTION
This changes allow code mirror to replace a tab with a string of spaces with size of the indent unit defined in the instantiation of the editor

That is whenever a user presses a tab, it will be changed automatically with spaces

@0xDCA @milderhc @larranaga 