### PR TITLE
Diff show empty lines

### DIFF
--- a/inginious/frontend/common/static/js/task.js
+++ b/inginious/frontend/common/static/js/task.js
@@ -537,10 +537,12 @@ function parseOutputDiff(diff) {
       output = '<span class="diff-missing-output">' + line.substring(1) + '</span>';
     } else if (line.startsWith("+")) {
       output = '<span class="diff-additional-output">' + line.substring(1) + '</span>';
-    } else if (line.startsWith(" ") || line === "") {
+    } else if (line.startsWith(" ")) {
       output = '<span class="diff-common">' + line.substring(1) + '</span>';
     } else if (line.startsWith("...")) {
       output = '<span class="diff-position-control">' + line + '</span>';
+    } else if (line === "") {
+      output = line;
     } else {
       throw new Error("Unable to parse diff line: " + line);
     }

--- a/inginious/frontend/common/static/js/task.js
+++ b/inginious/frontend/common/static/js/task.js
@@ -542,6 +542,8 @@ function parseOutputDiff(diff) {
     } else if (line.startsWith("...")) {
       output = '<span class="diff-position-control">' + line + '</span>';
     } else if (line === "") {
+      // The diff output includes empty lines after position control lines, so we keep them
+      // unformatted to avoid misleading the user (they are not actually part of any of the outputs)
       output = line;
     } else {
       throw new Error("Unable to parse diff line: " + line);

--- a/inginious/frontend/webapp/static/css/UNJudge.css
+++ b/inginious/frontend/webapp/static/css/UNJudge.css
@@ -30,3 +30,13 @@
   font-style: italic;
   font-weight: bold;
 }
+
+.diff-common, .diff-missing-output, .diff-additional-output {
+  display: inline-block;
+
+  /* Make sure the background is shown even if the line is empty. */
+  min-height: 1em;
+  min-width: 4px;
+  margin-top: 1px;
+  margin-bottom: 1px;
+}


### PR DESCRIPTION
This PR modifies the CSS styles for diff lines so empty diff lines are always shown. This helps the user to debug differences of only an End Of Line