### PR TITLE
Change message when unable to create file

### DIFF
--- a/inginious/frontend/webapp/pages/course_admin/task_edit_file.py
+++ b/inginious/frontend/webapp/pages/course_admin/task_edit_file.py
@@ -161,7 +161,7 @@ class CourseTaskFiles(INGIniousAdminPage):
 
         wanted_path = self.verify_path(courseid, taskid, path, True)
         if wanted_path is None:
-            return self.show_tab_file(courseid, taskid, "Invalid new path")
+            return self.show_tab_file(courseid, taskid, "The folder is not in the server yet, please click 'save changes' first")
         curpath = self.task_factory.get_directory_path(courseid, taskid)
         rel_path = os.path.relpath(wanted_path, curpath)
 
@@ -185,7 +185,7 @@ class CourseTaskFiles(INGIniousAdminPage):
 
         wanted_path = self.verify_path(courseid, taskid, path, True)
         if wanted_path is None:
-            return self.show_tab_file(courseid, taskid, "Invalid new path")
+            return self.show_tab_file(courseid, taskid, "The folder is not in the server yet, please click 'save changes' first")
         curpath = self.task_factory.get_directory_path(courseid, taskid)
         rel_path = os.path.relpath(wanted_path, curpath)
 


### PR DESCRIPTION
Give more descriptive error so that the user knows that he has to save the task and then the folder is available for having files