### PR TITLE
Travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,10 @@ before_install:
   - sudo chmod +x /usr/sbin/policy-rc.d
   - pip install --upgrade pip
 install:
-  - curl -sSL https://get.docker.com/ | sh
   - sudo apt-get install slirp libtidy-* xvfb
   - sudo usermod -aG docker "$USER"
   - git clone git://github.com/cptactionhank/sekexe
   - pip install --process-dependency-links --upgrade .
-  - sudo mkdir /var/lib/docker
-  - sudo mkdir /etc/docker
   - sudo chmod -R 777 /var/lib/docker
   - sudo chmod -R 777 /etc/docker
   - sudo mkdir /agent_volume

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 # the code for this .Travis.yml has been mostly taken from https://github.com/haiwen/seafile-docker/blob/master/.travis.yml
+dist: trusty
+sudo: required
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 sudo: required
 language: python
 python:
-  - "2.7"
+  - "3.5"
 env:
   global:
     - "HOST_IP=$(/sbin/ifconfig venet0:0 | grep 'inet addr' | awk -F: '{print $2}' | awk '{print $1}')"

--- a/inginious/common/tasks.py
+++ b/inginious/common/tasks.py
@@ -5,7 +5,7 @@
 
 """ Task """
 from inginious.common.base import id_checker
-from inginious.common.tasks_problems import CodeProblem, CodeSingleLineProblem, MultipleChoiceProblem, MatchProblem, CodeFileProblem, CodeMultipleLanguagesProblem
+from inginious.common.tasks_problems import CodeProblem, CodeSingleLineProblem, MultipleChoiceProblem, MatchProblem, CodeFileProblem, CodeMultipleLanguagesProblem, CodeFileMultipleLanguagesProblem
 
 
 class Task(object):


### PR DESCRIPTION
Make Travis run with Ubuntu 14.04 instead of 12.04 (Due to deprecated docker)
Change python version to 3.5 to fix the deployment
Fix a dependency issue that kept the test failing
