### PR TITLE
User docutils 0.13.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 install_requires = [
     "docker-py>=1.9.0",
-    "docutils>=0.12",
+    "docutils==0.13.1",
     "pymongo>=3.2.2",
     "PyYAML>=3.11",
     "web.py>=0.40.dev0",


### PR DESCRIPTION
This PR's objective is to fix the parse_test.py module that depends on a feature not present in docutils-0.14 (and almost surely newer versions as well). Therefore the version of the dependence is set to 0.13.1 